### PR TITLE
Throw error if action is already bound to store.

### DIFF
--- a/src/alt/store/StoreMixin.js
+++ b/src/alt/store/StoreMixin.js
@@ -61,6 +61,12 @@ const StoreMixin = {
 
     // You can pass in the constant or the function itself
     const key = symbol[Sym.ACTION_KEY] ? symbol[Sym.ACTION_KEY] : symbol
+    if (this[Sym.LISTENERS].hasOwnProperty(key)) {
+      throw new ReferenceError(
+        `The action ${key.toString()} has already been bound to store` +
+        `${this._storeName}`
+      )
+    }
     this[Sym.LISTENERS][key] = handler.bind(this)
     this[Sym.ALL_LISTENERS].push(Symbol.keyFor(key))
   },

--- a/test/bound-listeners-test.js
+++ b/test/bound-listeners-test.js
@@ -42,6 +42,18 @@ class BindActions {
   two() { }
 }
 
+class SameActionMultipleTimes {
+  constructor() {
+    this.bindListeners({
+      oneFirst: Actions.ONE,
+      oneSecond: Actions.ONE
+    })
+  }
+
+  oneFirst() { }
+  oneSecond() { }
+}
+
 
 export default {
   'Exporting listener names': {
@@ -69,6 +81,12 @@ export default {
         myStore.boundListeners.indexOf(Symbol.keyFor(Actions.ONE)) > -1 &&
         myStore.boundListeners.indexOf(Symbol.keyFor(Actions.TWO)) > -1
       )
+    },
+
+    'when binding the same action to multiple listeners'() {
+      assert.throws(() => {
+        alt.createStore(SameActionMultipleTimes)
+      })
     },
   }
 }


### PR DESCRIPTION
This will prevent accidental multiple binding of actions to store
listeners.
